### PR TITLE
delete all absolute paths for css/js file

### DIFF
--- a/docs/assets/js/cardFilter_gazaOnly.js
+++ b/docs/assets/js/cardFilter_gazaOnly.js
@@ -3,7 +3,7 @@ const visualization = document.getElementById("card-visualization");
 const countryFilter = document.getElementById("countryFilter");
 
 
-fetch("/docs/data/reporters_extra_columns_feb8_gaza_only.csv")
+fetch("/data/reporters_extra_columns_feb8_gaza_only.csv")
   .then(response => response.text())
   .then(csvData => {
     // Parse the CSV data into an array of objects

--- a/docs/assets/js/searchBarCard.js
+++ b/docs/assets/js/searchBarCard.js
@@ -4,7 +4,7 @@ document.addEventListener("DOMContentLoaded", function() {
   let data = [];
 
   async function loadCSV() {
-    const response = await fetch('/docs/data/reporters_extra_columns_feb8_gaza_only.csv');
+    const response = await fetch('/data/reporters_extra_columns_feb8_gaza_only.csv');
     const text = await response.text();
 
     // Parse CSV using PapaParse

--- a/docs/assets/js/sumup_filter.js
+++ b/docs/assets/js/sumup_filter.js
@@ -1,6 +1,6 @@
 // Function to fetch and parse JSON data
 async function fetchJSON(columnName) {
-    const response = await fetch('/docs/data/reporters_extra_columns_feb8.json');
+    const response = await fetch('/data/reporters_extra_columns_feb8.json');
     const data = await response.json();
     return data.map(item => {
         const value = item[columnName];

--- a/docs/database/index.html
+++ b/docs/database/index.html
@@ -580,7 +580,7 @@
             <select id="country-select" class="dropdown-content" ></select>
             <br>
             <p>Total killed journalists: <span id="total-journalists"></span></p>
-            <script src="/docs/assets/js/sumup_filter.js"></script>
+            <script src="/assets/js/sumup_filter.js"></script>
         </section>
         <section id="section-1-search">
             <!-- Search input -->
@@ -592,7 +592,7 @@
             <!-- Include the PapaParse library -->
             <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.3.0/papaparse.min.js"></script>
             <!-- Link to my searchBarCard.js -->
-            <script src="/docs/assets/js/searchBarCard.js"></script>
+            <script src="/assets/js/searchBarCard.js"></script>
         </section>
         <section id="section-2-filter">
             <p>Filter by:</p>
@@ -620,7 +620,7 @@
             <div id="card-visualization"></div>
             <!--Import d3.j3 library-->
             <script src="https://d3js.org/d3.v7.min.js"></script>
-            <script src="/docs/assets/js/cardFilter_gazaOnly.js"></script>
+            <script src="/assets/js/cardFilter_gazaOnly.js"></script>
             <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.13/xlsx.full.min.js"></script>
 
         </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Assistant"> <!-- body text fonts -->
     <link href=https://api.mapbox.com/mapbox-gl-js/v3.1.2/mapbox-gl.css rel="stylesheet"> <!-- interactive map -->
     <script src=https://api.mapbox.com/mapbox-gl-js/v3.2.0/mapbox-gl.js></script> <!-- interactive map -->
-    <link rel="stylesheet" type="text/css" href="/docs/assets/css/mainStyle.css">
+    <link rel="stylesheet" type="text/css" href="/assets/css/mainStyle.css">
 </head>
 
 <body>	 
@@ -48,8 +48,8 @@
                 </p>
                 <br>        
                 <div class="button-container">
-                    <button id="databaseButton" class="button">Explore the Database</button>
-                    <button id="storyButton" class="button">Read the Story</button>
+                    <button id="databaseButton" class="button"><a href="https://gaza-reporters.github.io/database/">Explore the Database</a></button>
+                    <button id="storyButton" class="button"><a href="#section-1">Read the Story</a></button>
                 </div>
                 <br>        
             </section>
@@ -64,7 +64,7 @@
 
 
         <div id="map"></div>
-        <script src="/docs/assets/js/map.js"></script>
+        <script src="/assets/js/map.js"></script>
         <br>
         <br>
             


### PR DESCRIPTION
This is because our GitHub Pages site is currently being built from the /docs folder in the main branch. If we cite our CSS/JS files as "/docs/assets/css/...", the HTML file will continue to search for the "docs" folder inside the "docs" folder, leading to a failure to locate the CSS/JS files.